### PR TITLE
Update CMIOKit submodule to use https over git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "CMIOKit"]
 	path = CMIOKit
-	url = git@github.com:lvsti/CMIOKit.git
+	url = https://github.com/lvsti/CMIOKit.git


### PR DESCRIPTION
This avoids:

```bash
Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:lvsti/CMIOKit.git' into submodule path '/Users/djones/Code/Cameo/CMIOKit' failed
Failed to clone 'CMIOKit' a second time, aborting
```

when installing the submodules.